### PR TITLE
Pad hour with a zero instead of a space

### DIFF
--- a/PCI_Configs.sh
+++ b/PCI_Configs.sh
@@ -54,7 +54,7 @@ version=1.4
 
 # Needed Variables - DO NOT CHANGE
 # ******************************************************************************
-fdate=`date +%m.%d.%y-%k.%M`
+fdate=`date +%m.%d.%y-%H.%M`
 # echo $fdate
 USERPROFILE=$(eval echo ~${SUDO_USER})
 # ******************************************************************************


### PR DESCRIPTION
Use %H instead of %k so the hour in the date string is padded with a
zero instead of a space. The difference is file names that have a name that looks like:

```
> date +%m.%d.%y-%k.%M
04.11.17- 1.00
```

Versus:

```
> date +%m.%d.%y-%H.%M
04.11.17-01.01
```

The latter is less cryptic. The former makes it look like some variable didn't get expanded properly.