### PR TITLE
Remove /etc/services grep from the script

### DIFF
--- a/PCI_Configs.sh
+++ b/PCI_Configs.sh
@@ -34,9 +34,9 @@
 # -----------
 # Auditing tool to check for PCI Compliance and the specific requirements
 # associated with the corresponding output files.
-# 
-# It is intended to be run by security auditors and pentetration testers 
-# against systems they have been engaged to assess, and also by system 
+#
+# It is intended to be run by security auditors and pentetration testers
+# against systems they have been engaged to assess, and also by system
 # admnisitrators who want to check configuration files for PCI Compliance.
 #
 # Ensure that you have the appropriate legal permission before running it
@@ -168,9 +168,7 @@ echo --------------------------------------------------
 	netstat -tulpn >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening Services 3.txt"
 	lsof -i >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening Services 4.txt"
 	lsof -i :23 >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening Services Telnet.txt"
-	grep 23 /etc/services >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening Services Telnet 2.txt"
-	lsof -i :21 >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening FTP 2.txt"
-	grep 21 /etc/services >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening FTP.txt"
+	lsof -i :21 >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening FTP.txt"
 	chkconfig --list >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening Services 5.txt"
 	chkconfig --list | grep 3:on >> "$tempdir/Req 2/2.2.2 $HOSTNAME Listening Services 6.txt"
 echo --------------------------------------------------
@@ -215,7 +213,7 @@ echo --------------------------------------------------
 	cat /etc/xntp.conf >> "$tempdir/Req 10/10.4 $HOSTNAME ntp config 2.txt"
 echo --------------------------------------------------
 echo  Grabbing Logging Settings
-echo --------------------------------------------------	
+echo --------------------------------------------------
 	cat /etc/rsyslog.conf >> "$tempdir/Req 10/10.1 $HOSTNAME Log Settings.txt"
 	cat /etc/syslog.conf >> "$tempdir/Req 10/10.1 $HOSTNAME Log Settings 2.txt"
 	cat /etc/rsyslog.d/* >> "$tempdir/Req 10/10.1 $HOSTNAME Log Settings 3.txt"


### PR DESCRIPTION
Every year, we use this script as part of our assessment, and every year
I get questions about all the services we're running.  "Why are we
running FTP and Telnet?" "We're not." It's the output of this script
that throws the assessor.

Specifically, the `grep 21 /etc/services` line.  This produces a ton of
irrelevant information. `/etc/services` is a port/protocol
"registration" for the local system.  It helps other tools like
`netstat`, `lsof`, and `ss` provide human readable names to their output
of ports.  It does *not* have anything to do with running or configured
services.

`grep 21 /etc/services` also is an incorrect use of `grep` as it matches
all lines containing '21', whether or not it has anything to do with
port 21.

I'm removing these two `grep .. /etc/services` lines from the script as
they are confusing and unhelpful and do not provide any PCI relevant
information.